### PR TITLE
Add initial unit tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit = 
+    # ignore all test cases in tests/
+    tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ desktop.ini
 .scratch/
 .passcode_pin
 certs/
+.test_temp

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true,
+  "python.analysis.extraPaths": [
+    "./aqchat"
+  ]
+}

--- a/aqchat/pipelines/code_memory_pipeline.py
+++ b/aqchat/pipelines/code_memory_pipeline.py
@@ -78,10 +78,12 @@ class CodeMemoryPipeline(AbstractMemoryPipeline):
             try:
                 self.vector_store = Chroma(
                     persist_directory=str(self.persist_directory),
-                    embedding=FastEmbedEmbeddings(),
+                    embedding_function=FastEmbedEmbeddings(),
                 )
                 self._build_chain()  # sets up self.retriever
-            except Exception:
+            except Exception as ex:
+                print(f"WARNING: Could not initialize vector stores from disk: {ex}")
+                
                 # Corrupt or incompatible store – start fresh
                 self.vector_store = None
                 self.retriever = None

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = aqchat
+testpaths = tests/

--- a/test_data/test_repo/README.md
+++ b/test_data/test_repo/README.md
@@ -1,0 +1,3 @@
+# Test readme
+
+This is a test readme with some test information.

--- a/test_data/test_repo/hello.py
+++ b/test_data/test_repo/hello.py
@@ -1,0 +1,6 @@
+def hello() -> None:
+    print("Hello World!")
+
+
+print("This is a test Python code file.")
+hello()

--- a/test_data/test_repo/subdir/document.txt
+++ b/test_data/test_repo/subdir/document.txt
@@ -1,0 +1,1 @@
+This is a test document within a subdirectory.

--- a/tests/test_code_memory.py
+++ b/tests/test_code_memory.py
@@ -1,0 +1,52 @@
+import pytest
+import shutil
+from pipelines import CodeMemoryPipeline
+
+@pytest.fixture(scope="session")
+def memory_pipeline_new():
+    """Create a brand new memory pipeline."""
+
+    # clear previous persisted data
+    try:
+        shutil.rmtree("./.test_temp")
+    except FileNotFoundError:
+        # eat file not found exception,
+        # if it doesn't exist, we are happy
+        pass
+
+    memory = CodeMemoryPipeline(persist_directory="./.test_temp")
+
+    memory.ingest("test_data/test_repo")
+    yield memory
+
+def test_code_memory_init_new(memory_pipeline_new):
+    """Test if we could successfully initialize a brand new memory pipeline.
+    
+    This also depends on ingest() functioning properly, but we more or less
+    have to test that in the fixture, rather than the test itself.
+    """
+    assert memory_pipeline_new.has_vector_db()
+    assert memory_pipeline_new.ready_for_retrieval()
+
+def test_code_memory_invoke_new(memory_pipeline_new):
+    """Test querying the memory pipeline with ``invoke``"""
+    documents = memory_pipeline_new.invoke("Tell me about the README")
+
+    assert len(documents) > 0
+
+    # the best match should be the readme itself.
+    # the word "readme" appears several times in the readme,
+    # we will check if the best match contains the word "readme".
+    assert "readme" in documents[0].page_content
+
+def test_code_memory_invoke_new_extension(memory_pipeline_new):
+    """Test querying the memory pipeline with ``invoke`` about
+    a text file.
+    """
+    documents = memory_pipeline_new.invoke("What file has .txt extension?")
+
+    assert len(documents) > 0
+
+    # the best match should be the .txt file in the subdirectory,
+    # which contains the word "subdirectory"
+    assert "subdirectory" in documents[0].page_content


### PR DESCRIPTION
- Added some unit tests, starting with memory pipeline. The tests so far test if memory pipeline can init successfully, and some basic recall. Persisted data is wiped between sessions.
- One of the tests was failing, this uncovered a bug in `CodeMemoryPipeline` where a keyword arg to Chroma's constructor was misspelled. Fixed the bug, it was potentially causing issues when reopening a vector database from disk. Weirdly it didn't cause issues when running the server for real, but I think this was because it was re-ingesting the entire repo every load, but this is bad because the database doesn't filter duplicates right now.