### PR TITLE
Add custom boundary-based code splitters

### DIFF
--- a/aqchat/pipelines/boundary_splitter.py
+++ b/aqchat/pipelines/boundary_splitter.py
@@ -1,0 +1,193 @@
+import os
+from typing import List, Dict, Any, Optional, Iterable
+from langchain.text_splitter import TextSplitter
+from langchain.docstore.document import Document
+from pipelines.detectors import CodeBoundaryDetector
+from langchain_text_splitters.character import RecursiveCharacterTextSplitter
+from langchain_text_splitters import TextSplitter
+
+def _get_extension_from_path(path: str):
+    """
+    Extracts the file extension from a file path.
+    Returns None if there's no extension.
+    """
+    filename = os.path.basename(path)
+    dot_index = filename.rfind('.')
+    
+    if dot_index > 0: # Excludes dotfiles like .bashrc
+        return filename[dot_index:]
+    return None
+
+class CodeBoundaryTextSplitter(TextSplitter):
+    """
+    This class splits code files based on language-specific boundaries (classes, functions, etc.).
+
+    When splitting text, you must provide a dict mapping file extensions (for example `.py`) to a
+    CodeBoundaryDetector implementation for that language. If no boundary detector is available,
+    then by default the Langchain recursive text splitter will be used.
+    """
+    
+    def __init__(
+        self,
+        chunk_size: int = 4000,
+        chunk_overlap: int = 200,
+        length_function: callable = len,
+        keep_separator: bool = True,
+        add_start_index: bool = False,
+        strip_whitespace: bool = True,
+    ):
+        """
+        Initialize the CodeBoundaryTextSplitter.
+        
+        Args:
+            boundary_detector: The boundary detector for the specific language
+            chunk_size: Maximum size of each chunk
+            chunk_overlap: Overlap between chunks
+            length_function: Function to calculate text length
+            keep_separator: Whether to keep boundary separators
+            add_start_index: Whether to add start index to metadata
+            strip_whitespace: Whether to strip whitespace from chunks
+            default_splitter: This is used as a splitter for raw text documents,
+            as well as any extensions for which there is no available boundary detector.
+        """
+        super().__init__(
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+            length_function=length_function,
+            keep_separator=keep_separator,
+            add_start_index=add_start_index,
+            strip_whitespace=strip_whitespace,
+        )
+        self.default_splitter = RecursiveCharacterTextSplitter()
+    
+    def split_text(self, text: str, *, boundary_detector: CodeBoundaryDetector = None) -> List[str]:
+        """Split text based on code boundaries."""
+
+        # If no boundary detector was supplied for a specific language,
+        # default to the Langchain text splitter. This will work fine for e.g. text,
+        # markdown, etc.
+        if boundary_detector is None:
+            return self.default_splitter.split_text(text)
+
+        lines = text.split('\n')
+        boundaries = boundary_detector.find_boundaries(text)
+        
+        # Sort boundaries by start line
+        boundaries.sort(key=lambda x: x[0])
+        
+        chunks = []
+        current_pos = 0
+        
+        # Process each boundary
+        for start_line, end_line, boundary_type, indent_level in boundaries:
+            # Add any code before this boundary as a separate chunk
+            if start_line > current_pos:
+                pre_boundary_text = '\n'.join(lines[current_pos:start_line])
+                if pre_boundary_text.strip():
+                    chunks.extend(self._split_large_chunk(pre_boundary_text))
+            
+            # Add the boundary itself as a chunk
+            boundary_text = '\n'.join(lines[start_line:end_line + 1])
+            if boundary_text.strip():
+                chunks.extend(self._split_large_chunk(boundary_text))
+            
+            current_pos = end_line + 1
+        
+        # Add any remaining code after the last boundary
+        if current_pos < len(lines):
+            remaining_text = '\n'.join(lines[current_pos:])
+            if remaining_text.strip():
+                chunks.extend(self._split_large_chunk(remaining_text))
+        
+        return [chunk for chunk in chunks if chunk.strip()]
+    
+    def _split_large_chunk(self, text: str) -> List[str]:
+        """Split a chunk that exceeds the size limit."""
+        if self._length_function(text) <= self._chunk_size:
+            return [text]
+        
+        # If the chunk is too large, split it by lines
+        lines = text.split('\n')
+        chunks = []
+        current_chunk = []
+        current_size = 0
+        
+        for line in lines:
+            line_size = self._length_function(line + '\n')
+            
+            # If adding this line would exceed the limit, save current chunk
+            if current_size + line_size > self._chunk_size and current_chunk:
+                chunks.append('\n'.join(current_chunk))
+                current_chunk = []
+                current_size = 0
+            
+            current_chunk.append(line)
+            current_size += line_size
+        
+        # Add the last chunk if it has content
+        if current_chunk:
+            chunks.append('\n'.join(current_chunk))
+        
+        return chunks
+    
+    def create_documents(
+        self, 
+        texts: List[str], 
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+        *,
+        boundary_detectors: Dict[str, CodeBoundaryDetector],
+        include_metadata: bool = False
+    ) -> List[Document]:
+        """Create Document objects from texts."""
+        documents = []
+        
+        for i, text in enumerate(texts):
+            metadata = metadatas[i] if metadatas else {}
+
+            source: str = metadata.get("source")
+            if source:
+                # extract extension from the filename
+                ext = _get_extension_from_path(source)
+
+                if ext:
+                    boundary_detector = boundary_detectors.get(ext)
+            
+            # Split the text. We pass the boundary detector found for
+            # the file's extension, if none was found, then split_text
+            # will default to the Langchain text splitter.
+            chunks = self.split_text(text, boundary_detector=boundary_detector)
+            
+            # Create documents for each chunk
+            for j, chunk in enumerate(chunks):
+                doc_metadata = metadata.copy()
+
+                if include_metadata:
+                    doc_metadata.update({
+                        'chunk_index': j,
+                        'total_chunks': len(chunks),
+                    })
+                    if boundary_detector is not None:
+                        doc_metadata['boundary_types'] = boundary_detector.get_boundary_types()
+                    
+                    if self._add_start_index:
+                        doc_metadata['start_index'] = text.find(chunk)
+                
+                documents.append(Document(page_content=chunk, metadata=doc_metadata))
+        
+        return documents
+
+    def split_documents(self,
+                        documents: Iterable[Document],
+                        *,
+                        boundary_detectors: Dict[str, CodeBoundaryDetector],
+                        include_metadata: bool = False) -> List[Document]:
+        """Split documents."""
+        texts, metadatas = [], []
+        for doc in documents:
+            texts.append(doc.page_content)
+            metadatas.append(doc.metadata)
+        return self.create_documents(texts,
+                                     metadatas=metadatas,
+                                     boundary_detectors=boundary_detectors,
+                                     include_metadata=include_metadata)
+    

--- a/aqchat/pipelines/code_memory_pipeline.py
+++ b/aqchat/pipelines/code_memory_pipeline.py
@@ -9,7 +9,7 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter, Language
 from langchain_community.document_loaders import TextLoader
 from langchain_community.vectorstores import Chroma
 from langchain_community.embeddings import FastEmbedEmbeddings
-from langchain.vectorstores.utils import filter_complex_metadata
+from langchain_community.vectorstores.utils import filter_complex_metadata
 from pipelines.abstract_memory import AbstractMemoryPipeline
 
 class CodeMemoryPipeline(AbstractMemoryPipeline):

--- a/aqchat/pipelines/code_memory_pipeline.py
+++ b/aqchat/pipelines/code_memory_pipeline.py
@@ -7,7 +7,7 @@ from langchain_core.documents import Document
 
 from langchain.text_splitter import RecursiveCharacterTextSplitter, Language
 from langchain_community.document_loaders import TextLoader
-from langchain_community.vectorstores import Chroma
+from langchain_chroma.vectorstores import Chroma
 from langchain_community.embeddings import FastEmbedEmbeddings
 from langchain_community.vectorstores.utils import filter_complex_metadata
 from pipelines.abstract_memory import AbstractMemoryPipeline
@@ -111,7 +111,6 @@ class CodeMemoryPipeline(AbstractMemoryPipeline):
                 embedding=FastEmbedEmbeddings(),
                 persist_directory=str(self.persist_directory),
             )
-            self.vector_store.persist()
 
             # Build retriever and QA chain
             self._build_chain()
@@ -154,7 +153,6 @@ class CodeMemoryPipeline(AbstractMemoryPipeline):
                 chunks = self.text_splitter.split_documents(docs)
                 chunks = filter_complex_metadata(chunks)
                 self.vector_store.add_documents(chunks)
-                self.vector_store.persist()
 
             # Refresh retriever so it sees the latest state
             self._build_chain()

--- a/aqchat/pipelines/detectors/__init__.py
+++ b/aqchat/pipelines/detectors/__init__.py
@@ -1,0 +1,10 @@
+from typing import Dict
+from pipelines.detectors.boundary_detector import CodeBoundaryDetector
+from pipelines.detectors.detector_python import PythonBoundaryDetector
+from pipelines.detectors.detector_rust import RustBoundaryDetector
+
+__all__ = [
+    "CodeBoundaryDetector",
+    "PythonBoundaryDetector",
+    "RustBoundaryDetector"
+]

--- a/aqchat/pipelines/detectors/boundary_detector.py
+++ b/aqchat/pipelines/detectors/boundary_detector.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from typing import List, Tuple
+
+class CodeBoundaryDetector(ABC):
+    """Abstract base class for detecting code boundaries in different languages."""
+    
+    @abstractmethod
+    def find_boundaries(self, text: str) -> List[Tuple[int, int, str, int]]:
+        """
+        Find boundaries in the code text.
+        
+        Returns:
+            List of tuples: (start_line, end_line, boundary_type, indent_level)
+        """
+        pass
+    
+    @abstractmethod
+    def get_boundary_types(self) -> List[str]:
+        """Return list of boundary types this detector can identify."""
+        pass

--- a/aqchat/pipelines/detectors/detector_python.py
+++ b/aqchat/pipelines/detectors/detector_python.py
@@ -1,0 +1,53 @@
+import re
+from typing import List, Tuple
+from pipelines.detectors.boundary_detector import CodeBoundaryDetector
+
+class PythonBoundaryDetector(CodeBoundaryDetector):
+    """Boundary detector for Python code."""
+    
+    def __init__(self):
+        self.class_pattern = re.compile(r'^(\s*)class\s+\w+.*?:')
+        self.function_pattern = re.compile(r'^(\s*)def\s+\w+.*?:')
+        self.async_function_pattern = re.compile(r'^(\s*)async\s+def\s+\w+.*?:')
+    
+    def find_boundaries(self, text: str) -> List[Tuple[int, int, str, int]]:
+        """Find class and function boundaries in Python code."""
+        lines = text.split('\n')
+        boundaries = []
+        
+        for i, line in enumerate(lines):
+            # Check for class definition
+            class_match = self.class_pattern.match(line)
+            if class_match:
+                indent_level = len(class_match.group(1))
+                end_line = self._find_block_end(lines, i, indent_level)
+                boundaries.append((i, end_line, 'class', indent_level))
+            
+            # Check for function definition (including async)
+            func_match = self.function_pattern.match(line) or self.async_function_pattern.match(line)
+            if func_match:
+                indent_level = len(func_match.group(1))
+                end_line = self._find_block_end(lines, i, indent_level)
+                boundaries.append((i, end_line, 'function', indent_level))
+        
+        return boundaries
+    
+    def _find_block_end(self, lines: List[str], start_line: int, base_indent: int) -> int:
+        """Find the end of a code block based on indentation."""
+        for i in range(start_line + 1, len(lines)):
+            line = lines[i]
+            if line.strip() == '':  # Skip empty lines
+                continue
+            
+            # Calculate current line's indentation
+            current_indent = len(line) - len(line.lstrip())
+            
+            # If we find a line with same or less indentation, the block has ended
+            if current_indent <= base_indent:
+                return i - 1
+        
+        # If we reach the end of file, return the last line
+        return len(lines) - 1
+    
+    def get_boundary_types(self) -> List[str]:
+        return ['class', 'function']

--- a/aqchat/pipelines/detectors/detector_rust.py
+++ b/aqchat/pipelines/detectors/detector_rust.py
@@ -1,0 +1,128 @@
+import re
+from typing import List, Tuple
+from pipelines.detectors.boundary_detector import CodeBoundaryDetector
+
+class RustBoundaryDetector(CodeBoundaryDetector):
+    """Boundary detector for Rust code."""
+    
+    def __init__(self):
+        # Function patterns (pub/private, async, unsafe, const, etc.)
+        self.function_pattern = re.compile(r'^(\s*)(?:pub\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?fn\s+\w+')
+        
+        # Struct patterns (pub/private, with generics)
+        self.struct_pattern = re.compile(r'^(\s*)(?:pub\s+)?struct\s+\w+')
+        
+        # Trait patterns (pub/private, with generics)
+        self.trait_pattern = re.compile(r'^(\s*)(?:pub\s+)?trait\s+\w+')
+        
+        # Impl patterns (with generics, trait impls)
+        self.impl_pattern = re.compile(r'^(\s*)impl\s+')
+    
+    def find_boundaries(self, text: str) -> List[Tuple[int, int, str, int]]:
+        """Find function, struct, trait, and impl boundaries in Rust code."""
+        lines = text.split('\n')
+        boundaries = []
+        
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.strip()
+            
+            # Skip regular comments and empty lines
+            if stripped.startswith('//') and not stripped.startswith('///') and not stripped.startswith('//!') or stripped == '':
+                i += 1
+                continue
+            
+            # Check if this line starts a code item (function, struct, trait, impl)
+            func_match = self.function_pattern.match(line)
+            struct_match = self.struct_pattern.match(line)
+            trait_match = self.trait_pattern.match(line)
+            impl_match = self.impl_pattern.match(line)
+            
+            if func_match or struct_match or trait_match or impl_match:
+                # Found a code item, now find its actual start including attributes and docs
+                start_line = self._find_item_start(lines, i)
+                
+                # Determine the type and base indentation
+                if func_match:
+                    item_type = 'function'
+                    indent_level = len(func_match.group(1))
+                elif struct_match:
+                    item_type = 'struct'
+                    indent_level = len(struct_match.group(1))
+                elif trait_match:
+                    item_type = 'trait'
+                    indent_level = len(trait_match.group(1))
+                else:  # impl_match
+                    item_type = 'impl'
+                    indent_level = len(impl_match.group(1))
+                
+                # Find the end of the code block
+                end_line = self._find_rust_block_end(lines, i, indent_level)
+                boundaries.append((start_line, end_line, item_type, indent_level))
+            
+            i += 1
+        
+        return boundaries
+    
+    def _find_item_start(self, lines: List[str], item_line: int) -> int:
+        """Find the actual start of a code item including attributes and doc comments."""
+        start_line = item_line
+        
+        # Look backwards for attributes and doc comments
+        for i in range(item_line - 1, -1, -1):
+            line = lines[i]
+            stripped = line.strip()
+            
+            # Check if this line is an attribute
+            if stripped.startswith('#[') or stripped.startswith('#!'):
+                start_line = i
+                continue
+            
+            # Check if this line is a doc comment
+            if stripped.startswith('///') or stripped.startswith('//!'):
+                start_line = i
+                continue
+            
+            # If we find an empty line, continue looking (attributes/docs can be separated)
+            if stripped == '':
+                continue
+            
+            # If we find anything else, stop looking
+            break
+        
+        return start_line
+    
+    def _find_rust_block_end(self, lines: List[str], start_line: int, base_indent: int) -> int:
+        """Find the end of a Rust code block using brace matching."""
+        brace_count = 0
+        found_opening_brace = False
+        
+        for i in range(start_line, len(lines)):
+            line = lines[i]
+            
+            # Skip comments
+            if line.strip().startswith('//'):
+                continue
+            
+            # Count braces (simple approach - doesn't handle strings/comments perfectly)
+            for char in line:
+                if char == '{':
+                    brace_count += 1
+                    found_opening_brace = True
+                elif char == '}':
+                    brace_count -= 1
+                    
+                    # If we've closed all braces, we found the end
+                    if found_opening_brace and brace_count == 0:
+                        return i
+            
+            # Handle single-line items without braces (like struct declarations)
+            if i == start_line and ';' in line:
+                return i
+        
+        # If we reach the end of file, return the last line
+        return len(lines) - 1
+    
+    def get_boundary_types(self) -> List[str]:
+        return ['function', 'struct', 'trait', 'impl']

--- a/aqchat/requirements.txt
+++ b/aqchat/requirements.txt
@@ -2,6 +2,7 @@ python-dotenv==1.1.1
 GitPython==3.1.44
 langchain==0.3.26
 langchain_community==0.3.26
+langchain_chroma==0.2.4
 fastembed==0.7.1
 chromadb==1.0.13
 streamlit==1.46.1

--- a/test_data/splitting/sample_py.py
+++ b/test_data/splitting/sample_py.py
@@ -1,0 +1,97 @@
+import datetime
+import random
+from typing import List
+
+def generate_task_id() -> str:
+    """Utility function to generate a random task ID."""
+    timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+    random_part = random.randint(1000, 9999)
+    return f"TASK-{timestamp}-{random_part}"
+
+def is_valid_description(desc: str) -> bool:
+    """Utility function to validate a task description."""
+    return len(desc.strip()) > 0
+
+class Task:
+    """
+    Represents a single task in a task manager.
+    """
+
+    def __init__(self, description: str):
+        if not is_valid_description(description):
+            raise ValueError("Description must not be empty")
+
+        self._id = generate_task_id()
+        self._description = description
+        self._created_at = datetime.datetime.now()
+        self._completed = False
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        return self._created_at
+
+    @property
+    def is_completed(self) -> bool:
+        return self._completed
+
+    def mark_completed(self):
+        self._completed = True
+
+    def __str__(self) -> str:
+        status = "X" if self._completed else " "
+        return f"[{status}] {self._description} (Created: {self._created_at.strftime('%Y-%m-%d %H:%M:%S')})"
+
+class TaskManager:
+    """
+    Manages a collection of tasks.
+    """
+
+    def __init__(self):
+        self._tasks: List[Task] = []
+
+    def add_task(self, description: str) -> Task:
+        task = Task(description)
+        self._tasks.append(task)
+        return task
+
+    def list_tasks(self) -> List[Task]:
+        return self._tasks
+
+    def get_incomplete_tasks(self) -> List[Task]:
+        return [task for task in self._tasks if not task.is_completed]
+
+    def complete_task(self, task_id: str) -> bool:
+        for task in self._tasks:
+            if task.id == task_id:
+                task.mark_completed()
+                return True
+        return False
+
+# Run if script is executed directly
+if __name__ == "__main__":
+    manager = TaskManager()
+
+    print("Adding tasks...")
+    manager.add_task("Buy groceries")
+    manager.add_task("Walk the dog")
+    manager.add_task("Read a book")
+
+    print("\nCurrent tasks:")
+    for task in manager.list_tasks():
+        print(task)
+
+    print("\nCompleting the first task...")
+    first_task_id = manager.list_tasks()[0].id
+    manager.complete_task(first_task_id)
+
+    print("\nIncomplete tasks:")
+    for task in manager.get_incomplete_tasks():
+        print(task)

--- a/test_data/splitting/sample_rs.rs
+++ b/test_data/splitting/sample_rs.rs
@@ -1,0 +1,85 @@
+//! @brief A simple logging system with pluggable output backends.
+//!
+//! This demonstrates basic use of structs, traits, imports, and decorators.
+
+use std::fmt;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// @brief Get the current Unix timestamp in seconds.
+fn current_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_secs()
+}
+
+/// @brief Levels of logging severity.
+#[derive(Debug, Clone, Copy)]
+enum LogLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+/// @brief A simple structure representing a log message.
+#[derive(Debug)]
+struct LogMessage {
+    timestamp: u64,
+    level: LogLevel,
+    content: String,
+}
+
+impl fmt::Display for LogMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{}][{:?}] {}",
+            self.timestamp,
+            self.level,
+            self.content
+        )
+    }
+}
+
+/// @brief A trait for anything that can handle log messages.
+trait LogBackend {
+    /// @brief Handle a log message.
+    fn log(&self, message: &LogMessage);
+}
+
+/// @brief A backend that logs messages to stdout.
+struct ConsoleLogger;
+
+/// @allow(dead_code)
+impl ConsoleLogger {
+    /// @brief Create a new ConsoleLogger.
+    fn new() -> Self {
+        ConsoleLogger
+    }
+}
+
+impl LogBackend for ConsoleLogger {
+    fn log(&self, message: &LogMessage) {
+        println!("{}", message);
+    }
+}
+
+/// @brief A utility function to send a log message.
+fn log_message<B: LogBackend>(backend: &B, level: LogLevel, content: &str) {
+    let msg = LogMessage {
+        timestamp: current_timestamp(),
+        level,
+        content: content.to_string(),
+    };
+
+    backend.log(&msg);
+}
+
+/// @brief Entry point for the program.
+fn main() {
+    let logger = ConsoleLogger::new();
+
+    log_message(&logger, LogLevel::Info, "Application started");
+    log_message(&logger, LogLevel::Warning, "Low disk space");
+    log_message(&logger, LogLevel::Error, "Unable to open file");
+}

--- a/tests/splitter/test_python_splitter.py
+++ b/tests/splitter/test_python_splitter.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+from typing import List
+from pipelines.boundary_splitter import CodeBoundaryTextSplitter
+from pipelines.detectors import CodeBoundaryDetector, PythonBoundaryDetector
+
+def _get_test_code_and_detector() -> str | None:
+    code = Path(f"test_data/splitting/sample_py.py").read_text("utf-8")
+    detector = PythonBoundaryDetector()
+    
+    return code, detector
+
+def _split_with_detector(code: str, detector: CodeBoundaryDetector) -> List[str]:
+    splitter = CodeBoundaryTextSplitter()
+    chunks = [chunk.strip() for chunk in splitter.split_text(code, boundary_detector=detector)]
+    return chunks
+
+def test_python_imports():
+    """This tests if the splitter can successfully split imports
+    at the top of the code file.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """import datetime
+import random
+from typing import List"""
+    
+    assert expected in result
+
+def test_python_func_isolated():
+    """This tests if the splitter can successfully split a function
+    which is not within a class.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """def is_valid_description(desc: str) -> bool:
+    \"\"\"Utility function to validate a task description.\"\"\"
+    return len(desc.strip()) > 0"""
+    
+    assert expected in result
+
+def test_python_class():
+    """This tests if the splitter can successfully split an entire
+    class definition.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """class TaskManager:
+    \"\"\"
+    Manages a collection of tasks.
+    \"\"\"
+
+    def __init__(self):
+        self._tasks: List[Task] = []
+
+    def add_task(self, description: str) -> Task:
+        task = Task(description)
+        self._tasks.append(task)
+        return task
+
+    def list_tasks(self) -> List[Task]:
+        return self._tasks
+
+    def get_incomplete_tasks(self) -> List[Task]:
+        return [task for task in self._tasks if not task.is_completed]
+
+    def complete_task(self, task_id: str) -> bool:
+        for task in self._tasks:
+            if task.id == task_id:
+                task.mark_completed()
+                return True
+        return False"""
+    
+    assert expected in result
+
+def test_python_func_class_member():
+    """This tests if the splitter can successfully split a function
+    that sits inside a class definition.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """def complete_task(self, task_id: str) -> bool:
+        for task in self._tasks:
+            if task.id == task_id:
+                task.mark_completed()
+                return True
+        return False"""
+    
+    assert expected in result
+
+def test_python_main_code():
+    """This tests if the splitter can successfully split code at the end
+    of the file which is not within a function or class definition.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """# Run if script is executed directly
+if __name__ == "__main__":
+    manager = TaskManager()
+
+    print("Adding tasks...")
+    manager.add_task("Buy groceries")
+    manager.add_task("Walk the dog")
+    manager.add_task("Read a book")
+
+    print("\\nCurrent tasks:")
+    for task in manager.list_tasks():
+        print(task)
+
+    print("\\nCompleting the first task...")
+    first_task_id = manager.list_tasks()[0].id
+    manager.complete_task(first_task_id)
+
+    print("\\nIncomplete tasks:")
+    for task in manager.get_incomplete_tasks():
+        print(task)"""
+    
+    assert expected in result

--- a/tests/splitter/test_rust_splitter.py
+++ b/tests/splitter/test_rust_splitter.py
@@ -65,6 +65,8 @@ struct LogMessage {
     content: String,
 }"""
 
+    assert expected in result
+
 def test_rust_impl():
     """This tests if the splitter can successfully split an impl,
     including function definitions that sit inside.

--- a/tests/splitter/test_rust_splitter.py
+++ b/tests/splitter/test_rust_splitter.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+from typing import List
+from pipelines.boundary_splitter import CodeBoundaryTextSplitter
+from pipelines.detectors import CodeBoundaryDetector, RustBoundaryDetector
+
+def _get_test_code_and_detector() -> str | None:
+    code = Path(f"test_data/splitting/sample_rs.rs").read_text("utf-8")
+    detector = RustBoundaryDetector()
+    
+    return code, detector
+
+def _split_with_detector(code: str, detector: CodeBoundaryDetector) -> List[str]:
+    splitter = CodeBoundaryTextSplitter()
+    chunks = [chunk.strip() for chunk in splitter.split_text(code, boundary_detector=detector)]
+    return chunks
+
+def test_rust_imports():
+    """This tests if the splitter can successfully split imports
+    at the top of the code file.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """//! @brief A simple logging system with pluggable output backends.
+//!
+//! This demonstrates basic use of structs, traits, imports, and decorators.
+
+use std::fmt;
+use std::time::{SystemTime, UNIX_EPOCH};"""
+    
+    assert expected in result
+
+def test_rust_func_isolated():
+    """This tests if the splitter can successfully split a function
+    which is not within an impl.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """/// @brief A utility function to send a log message.
+fn log_message<B: LogBackend>(backend: &B, level: LogLevel, content: &str) {
+    let msg = LogMessage {
+        timestamp: current_timestamp(),
+        level,
+        content: content.to_string(),
+    };
+
+    backend.log(&msg);
+}"""
+    
+    assert expected in result
+
+def test_rust_struct_decorated():
+    """This tests if the splitter can successfully split a struct.
+    The splitter should also handle decorators and comments.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """/// @brief A simple structure representing a log message.
+#[derive(Debug)]
+struct LogMessage {
+    timestamp: u64,
+    level: LogLevel,
+    content: String,
+}"""
+
+def test_rust_impl():
+    """This tests if the splitter can successfully split an impl,
+    including function definitions that sit inside.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """impl fmt::Display for LogMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{}][{:?}] {}",
+            self.timestamp,
+            self.level,
+            self.content
+        )
+    }
+}"""
+    
+    assert expected in result
+
+def test_rust_impl_decorated():
+    """This tests if the splitter can successfully split an impl,
+    even if the impl has a preceding comment/decorator.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """/// @allow(dead_code)
+impl ConsoleLogger {
+    /// @brief Create a new ConsoleLogger.
+    fn new() -> Self {
+        ConsoleLogger
+    }
+}"""
+    
+    assert expected in result
+
+def test_rust_func_impl():
+    """This tests if the splitter can successfully split a function
+    that sits inside an impl.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{}][{:?}] {}",
+            self.timestamp,
+            self.level,
+            self.content
+        )
+    }"""
+    
+    assert expected in result
+
+def test_rust_trait():
+    """This tests if the splitter can successfully split a trait.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """/// @brief A trait for anything that can handle log messages.
+trait LogBackend {
+    /// @brief Handle a log message.
+    fn log(&self, message: &LogMessage);
+}"""
+    
+    assert expected in result
+
+def test_rust_struct_decl():
+    """This tests if the splitter can successfully split a
+    struct without any members.
+    """
+    code, detector = _get_test_code_and_detector()
+    result = _split_with_detector(code, detector)
+
+    expected = """/// @brief A backend that logs messages to stdout.
+struct ConsoleLogger;"""
+    
+    assert expected in result
+
+    

--- a/tests/test_code_memory.py
+++ b/tests/test_code_memory.py
@@ -43,7 +43,7 @@ def test_code_memory_invoke_new_extension(memory_pipeline_new):
     """Test querying the memory pipeline with ``invoke`` about
     a text file.
     """
-    documents = memory_pipeline_new.invoke("What file has .txt extension?")
+    documents = memory_pipeline_new.invoke("Which is a plain text document?")
 
     assert len(documents) > 0
 


### PR DESCRIPTION
To address the current issues with Langchain's text splitter which is not very syntactically aware, "boundary-based code splitters" have been added. This is a method of splitting which involves looking at boundaries of certain code entities, i.e. where a class/function definition starts or ends.

To roughly illustrate, before it was like this:
- "What is the definition of SomeClass?" might end up fetching the first few lines of the class definition.
- "What is the definition of SomeFunction?" might fetch the first few lines of that function (if the function is larger than the chunk size) or a lot of irrelevant surrounding code (if the function is smaller than the chunk size).

This resulted in issues where the LLM was getting distracted by irrelevant context, or wasn't able to give a good answer because it lacked context.

Now, it's more like this:
- "What is the definition of SomeClass?" will probably fetch the exact class definition.
- "What is the definition of SomeFunction?" will probably fetch the exact function definition.

and the LLM is getting much more appropriate context.

Furthermore, the memory engine will switch between boundary detectors depending on the language. Python will use a Python-specific splitter, Rust will use a Rust splitter, and everything else will use Langchain's text splitter. And it will be fairly easy to add more supported languages in the future, just need to add a new boundary detector for that language.

Addresses https://github.com/JFarAur/aqchat/issues/12