### PR TITLE
Update PIN Interface

### DIFF
--- a/aqchat/app.py
+++ b/aqchat/app.py
@@ -3,7 +3,7 @@ import auth
 import chat
 import settings
 
-login_page = st.Page(auth.page_login, title="PIN Login"),
+login_page = [st.Page(auth.page_login, title="PIN Login")]
 
 pages = [
     st.Page(chat.page_chat, title="Chat"),

--- a/aqchat/app.py
+++ b/aqchat/app.py
@@ -3,11 +3,16 @@ import auth
 import chat
 import settings
 
+login_page = st.Page(auth.page_login, title="PIN Login"),
+
 pages = [
     st.Page(chat.page_chat, title="Chat"),
     st.Page(settings.page_settings, title="Settings"),
-    st.Page(auth.page_login, title="PIN Login"),
+    st.Page(auth.logout, title="Logout")
 ]
 
-pg = st.navigation(pages)
+if auth.has_authorized():
+    pg = st.navigation(pages)
+else:
+    pg = st.navigation(login_page)
 pg.run()

--- a/aqchat/auth.py
+++ b/aqchat/auth.py
@@ -24,6 +24,7 @@ def page_login():
 
     if has_authorized():
         st.success("You are already logged in.")
+        st.rerun()
         return
 
     with st.form(key="pin_form"):
@@ -34,5 +35,10 @@ def page_login():
             
             if has_authorized():
                 st.success("Login successful!")
+                st.rerun()
             else:
                 st.error("Incorrect PIN.")
+
+def logout():
+    st.session_state["auth_pin"] = None
+    st.rerun()

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -63,16 +63,17 @@ def page_settings():
         gh_user = st.text_input("Your Github Username :red[*]", value=config.get("gh_user", ""))
         gh_token = st.text_input("Github PAT", help="Personal Access Token, only required for private repositories.", value=config.get("gh_token", ""), type="password") # TODO: Find a way to align help tooltip so it's closer to label. Also add instructions on how to find the PAT, I couldn't make the tooltip multi-line.
         saved = st.form_submit_button("Save")
-        if saved and gh_user and repo_url:
-            try:
-                extract_repo_name(repo_url)
-            except:
-                st.error("Invalid repository URL, please verify the URL and try again.")
+        if saved:
+            if repo_url and gh_user:
+                try:
+                    extract_repo_name(repo_url)
+                except:
+                    st.error("Invalid repository URL, please verify the URL and try again.")
+                else:
+                    config["repo_url"] = repo_url
+                    config["gh_user"] = gh_user
+                    config["gh_token"] = gh_token
+                    st.success("Settings saved! Please refresh the app to fully apply changes.")
+                    save_config()
             else:
-                config["repo_url"] = repo_url
-                config["gh_user"] = gh_user
-                config["gh_token"] = gh_token
-                st.success("Settings saved! Please refresh the app to fully apply changes.")
-                save_config()
-        else:
-            st.error("Please fill all required fields.")
+                st.error("Please fill all required fields.")


### PR DESCRIPTION
I updated the PIN interface, now the app will display only the page for entering the PIN code upon access.

After successful authentication, the user will gain access to the Chat and Settings pages, and there is now a new Logout "page", all it does is log the user out by clearing the session state, and redirecting them to the PIN page.

This update also includes a fix for the error message in case of blank required fields in the settings page.

This was made to address issue #6 

Additional notes:

- Right now, clicking Logout will instantly log the user out, without any confirmation. It may be a good idea to add some kind of confirmation box in the future, to avoid accidental logouts.
- The Chat and Settings pages still have error messages in their functions in case the user is not logged in. These should no longer be necessary with this update, but I have decided not to remove them.