### PR TITLE
Create chat settings page

### DIFF
--- a/aqchat/app.py
+++ b/aqchat/app.py
@@ -7,6 +7,7 @@ login_page = [st.Page(auth.page_login, title="PIN Login")]
 
 pages = [
     st.Page(chat.page_chat, title="Chat"),
+    st.Page(settings.chat_settings, title="Chat Settings"),
     st.Page(settings.page_settings, title="Settings"),
     st.Page(settings.memory_settings, title="Memory"),
     st.Page(auth.logout, title="Logout")

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -21,10 +21,19 @@ def get_config() -> Dict[str, Any]:
             "chat": get_chat_defaults()}
 
 def get_chat_defaults():
-    return {"num_ctx": 2048, "temperature": 0.8, "repeat_last_n": 64, "repeat_penalty": 1.1, "top_k": 40, "top_p": 0.9, "min_p": 0.0}
+    return {"num_ctx": 2048, 
+            "temperature": 0.8, 
+            "repeat_last_n": 64, 
+            "repeat_penalty": 1.1, 
+            "top_k": 40, 
+            "top_p": 0.9, 
+            "min_p": 0.0}
 
 def get_memory_defaults():
-    return {"current_index": 0, "k_int": 6, "fetch_k": 20, "lambda_mult": 0.5}
+    return {"ret_strat": 0, 
+            "k_int": 6, 
+            "fetch_k": 20, 
+            "lambda_mult": 0.5}
 
 def save_config():
     """Persist configuration atomically."""
@@ -91,7 +100,7 @@ def memory_settings():
 
     config = get_config()
     options = ["MMR", "Similarity"]
-    ret_strat = st.selectbox("Retrieval Strategy", options, index=config["memory"]["current_index"])
+    ret_strat = st.selectbox("Retrieval Strategy", options, index=config["memory"]["ret_strat"])
     current_index = options.index(ret_strat)
     k_int = st.number_input("k", 1, 10, value=int(config["memory"]["k_int"]))
     disable_widget = ret_strat != "MMR"
@@ -99,7 +108,7 @@ def memory_settings():
     lambda_mult = st.number_input("Lambda mult", 0.0, 1.0, value=float(config["memory"]["lambda_mult"]), disabled=disable_widget)
     saved = st.button("Save")
     if saved:
-        config["memory"]["current_index"] = current_index
+        config["memory"]["ret_strat"] = current_index
         config["memory"]["k_int"] = k_int
         config["memory"]["fetch_k"] = fetch_k
         config["memory"]["lambda_mult"] = lambda_mult
@@ -111,14 +120,11 @@ def chat_settings():
     config=get_config()
 
     with st.form(key="chat_settings"):
-        context = st.container(border=True)
-        generation = st.container(border=True)
-
-        with context:
+        with st.container(border=True) as context:
             st.header("Context")
             num_ctx = st.number_input("num_ctx", 512, 131072, value=int(config["chat"]["num_ctx"]))
 
-        with generation:
+        with st.container(border=True) as generation:
             st.header("Generation")
             temperature = st.number_input("temperature", 0.0, 1.0, value=float(config["chat"]["temperature"]))
             repeat_last_n = st.number_input("repeat_last_n", -1, 512, value=int(config["chat"]["repeat_last_n"]))

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -19,6 +19,9 @@ def get_config() -> Dict[str, Any]:
     return {"repo_url": "", "gh_user": "", "gh_token": "",
             "memory": get_memory_defaults()}
 
+def get_chat_defaults():
+    return {"num_ctx": 2048, "temperature": 0.8, "repeat_last_n": 64, "repeat_penalty": 1.1, "top_k": 40, "top_p": 0.9, "min_p": 0.0}
+
 def get_memory_defaults():
     return {"ret_strat": "MMR", "k_int": 6, "fetch_k": 20, "lambda_mult": 0.5}
 

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -102,4 +102,33 @@ def memory_settings():
         save_config()
 
 def chat_settings():
-    pass
+    st.title("Chat Settings")
+    config=get_config()
+
+    context = st.container(border=True)
+    generation = st.container(border=True)
+
+    with context:
+        st.header("Context")
+        num_ctx = st.number_input("num_ctx", 512, 131072, value=config["chat"]["num_ctx"])
+
+    with generation:
+        st.header("Generation")
+        temperature = st.number_input("temperature", 0.0, 1.0, value=config["chat"]["temperature"])
+        repeat_last_n = st.number_input("repeat_last_n", -1, 512, value=config["chat"]["repeat_last_n"])
+        repeat_penalty = st.number_input("repeat_penalty", 0.0, 2.0, value=config["chat"]["repeat_penalty"])
+        top_k = st.number_input("top_k", 0, 100, value=config["chat"]["top_k"])
+        top_p = st.number_input("top_p", 0.0, 1.0, value=config["chat"]["top_p"])
+        min_p = st.number_input("min_p", 0.0, 1.0, value=config["chat"]["min_p"])
+        
+    saved = st.button("Save")
+    if saved:
+        config["chat"]["num_ctx"] = num_ctx
+        config["chat"]["temperature"] = temperature
+        config["chat"]["repeat_last_n"] = repeat_last_n
+        config["chat"]["repeat_penalty"] = repeat_penalty
+        config["chat"]["top_k"] = top_k
+        config["chat"]["top_p"] = top_p
+        config["chat"]["min_p"] = min_p
+        st.success("Settings saved! Please refresh the app to fully apply changes.")
+        save_config()

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -100,3 +100,6 @@ def memory_settings():
         config["memory"]["lambda_mult"] = lambda_mult
         st.success("Settings saved! Please refresh the app to fully apply changes.")
         save_config()
+
+def chat_settings():
+    pass

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -24,7 +24,7 @@ def get_chat_defaults():
     return {"num_ctx": 2048, "temperature": 0.8, "repeat_last_n": 64, "repeat_penalty": 1.1, "top_k": 40, "top_p": 0.9, "min_p": 0.0}
 
 def get_memory_defaults():
-    return {"ret_strat": "MMR", "k_int": 6, "fetch_k": 20, "lambda_mult": 0.5}
+    return {"current_index": 0, "k_int": 6, "fetch_k": 20, "lambda_mult": 0.5}
 
 def save_config():
     """Persist configuration atomically."""
@@ -90,15 +90,14 @@ def memory_settings():
     st.title("Memory Settings")
 
     config = get_config()
-    ret_strat = ["MMR", "Similarity"]
-    current_index = ret_strat.index(config["memory"]["ret_strat"])
+    ret_strat = st.selectbox("Retrieval Strategy", ["MMR", "Similarity"], index=config["memory"]["current_index"])
     k_int = st.number_input("k", 1, 10, value=int(config["memory"]["k_int"]))
     disable_widget = ret_strat != "MMR"
     fetch_k = st.number_input("Fetch k", 10, 100, value=int(config["memory"]["fetch_k"]) , disabled=disable_widget)
     lambda_mult = st.number_input("Lambda mult", 0.0, 1.0, value=float(config["memory"]["lambda_mult"]), disabled=disable_widget)
     saved = st.button("Save")
     if saved:
-        config["memory"]["ret_strat"] = ret_strat
+        config["memory"]["current_index"] = 0 if ret_strat == "MMR" else 1
         config["memory"]["k_int"] = k_int
         config["memory"]["fetch_k"] = fetch_k
         config["memory"]["lambda_mult"] = lambda_mult
@@ -114,16 +113,16 @@ def chat_settings():
 
     with context:
         st.header("Context")
-        num_ctx = st.number_input("num_ctx", 512, 131072, value=config["chat"]["num_ctx"])
+        num_ctx = st.number_input("num_ctx", 512, 131072, value=int(config["chat"]["num_ctx"]))
 
     with generation:
         st.header("Generation")
-        temperature = st.number_input("temperature", 0.0, 1.0, value=config["chat"]["temperature"])
-        repeat_last_n = st.number_input("repeat_last_n", -1, 512, value=config["chat"]["repeat_last_n"])
-        repeat_penalty = st.number_input("repeat_penalty", 0.0, 2.0, value=config["chat"]["repeat_penalty"])
-        top_k = st.number_input("top_k", 0, 100, value=config["chat"]["top_k"])
-        top_p = st.number_input("top_p", 0.0, 1.0, value=config["chat"]["top_p"])
-        min_p = st.number_input("min_p", 0.0, 1.0, value=config["chat"]["min_p"])
+        temperature = st.number_input("temperature", 0.0, 1.0, value=float(config["chat"]["temperature"]))
+        repeat_last_n = st.number_input("repeat_last_n", -1, 512, value=int(config["chat"]["repeat_last_n"]))
+        repeat_penalty = st.number_input("repeat_penalty", 0.0, 2.0, value=float(config["chat"]["repeat_penalty"]))
+        top_k = st.number_input("top_k", 0, 100, value=int(config["chat"]["top_k"]))
+        top_p = st.number_input("top_p", 0.0, 1.0, value=float(config["chat"]["top_p"]))
+        min_p = st.number_input("min_p", 0.0, 1.0, value=float(config["chat"]["min_p"]))
         
     saved = st.button("Save")
     if saved:

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -90,14 +90,16 @@ def memory_settings():
     st.title("Memory Settings")
 
     config = get_config()
-    ret_strat = st.selectbox("Retrieval Strategy", ["MMR", "Similarity"], index=config["memory"]["current_index"])
+    options = ["MMR", "Similarity"]
+    ret_strat = st.selectbox("Retrieval Strategy", options, index=config["memory"]["current_index"])
+    current_index = options.index(ret_strat)
     k_int = st.number_input("k", 1, 10, value=int(config["memory"]["k_int"]))
     disable_widget = ret_strat != "MMR"
     fetch_k = st.number_input("Fetch k", 10, 100, value=int(config["memory"]["fetch_k"]) , disabled=disable_widget)
     lambda_mult = st.number_input("Lambda mult", 0.0, 1.0, value=float(config["memory"]["lambda_mult"]), disabled=disable_widget)
     saved = st.button("Save")
     if saved:
-        config["memory"]["current_index"] = 0 if ret_strat == "MMR" else 1
+        config["memory"]["current_index"] = current_index
         config["memory"]["k_int"] = k_int
         config["memory"]["fetch_k"] = fetch_k
         config["memory"]["lambda_mult"] = lambda_mult

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -30,7 +30,7 @@ def get_chat_defaults():
             "min_p": 0.0}
 
 def get_memory_defaults():
-    return {"ret_strat": 0, 
+    return {"ret_strat": "mmr", 
             "k_int": 6, 
             "fetch_k": 20, 
             "lambda_mult": 0.5}
@@ -99,8 +99,9 @@ def memory_settings():
     st.title("Memory Settings")
 
     config = get_config()
+    dict_options = ["mmr", "similarity"]
     options = ["MMR", "Similarity"]
-    ret_strat = st.selectbox("Retrieval Strategy", options, index=config["memory"]["ret_strat"])
+    ret_strat = st.selectbox("Retrieval Strategy", options, index=dict_options.index(config["memory"]["ret_strat"]))
     current_index = options.index(ret_strat)
     k_int = st.number_input("k", 1, 10, value=int(config["memory"]["k_int"]))
     disable_widget = ret_strat != "MMR"
@@ -108,7 +109,7 @@ def memory_settings():
     lambda_mult = st.number_input("Lambda mult", 0.0, 1.0, value=float(config["memory"]["lambda_mult"]), disabled=disable_widget)
     saved = st.button("Save")
     if saved:
-        config["memory"]["ret_strat"] = current_index
+        config["memory"]["ret_strat"] = dict_options[current_index]
         config["memory"]["k_int"] = k_int
         config["memory"]["fetch_k"] = fetch_k
         config["memory"]["lambda_mult"] = lambda_mult

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -110,30 +110,31 @@ def chat_settings():
     st.title("Chat Settings")
     config=get_config()
 
-    context = st.container(border=True)
-    generation = st.container(border=True)
+    with st.form(key="chat_settings"):
+        context = st.container(border=True)
+        generation = st.container(border=True)
 
-    with context:
-        st.header("Context")
-        num_ctx = st.number_input("num_ctx", 512, 131072, value=int(config["chat"]["num_ctx"]))
+        with context:
+            st.header("Context")
+            num_ctx = st.number_input("num_ctx", 512, 131072, value=int(config["chat"]["num_ctx"]))
 
-    with generation:
-        st.header("Generation")
-        temperature = st.number_input("temperature", 0.0, 1.0, value=float(config["chat"]["temperature"]))
-        repeat_last_n = st.number_input("repeat_last_n", -1, 512, value=int(config["chat"]["repeat_last_n"]))
-        repeat_penalty = st.number_input("repeat_penalty", 0.0, 2.0, value=float(config["chat"]["repeat_penalty"]))
-        top_k = st.number_input("top_k", 0, 100, value=int(config["chat"]["top_k"]))
-        top_p = st.number_input("top_p", 0.0, 1.0, value=float(config["chat"]["top_p"]))
-        min_p = st.number_input("min_p", 0.0, 1.0, value=float(config["chat"]["min_p"]))
-        
-    saved = st.button("Save")
-    if saved:
-        config["chat"]["num_ctx"] = num_ctx
-        config["chat"]["temperature"] = temperature
-        config["chat"]["repeat_last_n"] = repeat_last_n
-        config["chat"]["repeat_penalty"] = repeat_penalty
-        config["chat"]["top_k"] = top_k
-        config["chat"]["top_p"] = top_p
-        config["chat"]["min_p"] = min_p
-        st.success("Settings saved! Please refresh the app to fully apply changes.")
-        save_config()
+        with generation:
+            st.header("Generation")
+            temperature = st.number_input("temperature", 0.0, 1.0, value=float(config["chat"]["temperature"]))
+            repeat_last_n = st.number_input("repeat_last_n", -1, 512, value=int(config["chat"]["repeat_last_n"]))
+            repeat_penalty = st.number_input("repeat_penalty", 0.0, 2.0, value=float(config["chat"]["repeat_penalty"]))
+            top_k = st.number_input("top_k", 0, 100, value=int(config["chat"]["top_k"]))
+            top_p = st.number_input("top_p", 0.0, 1.0, value=float(config["chat"]["top_p"]))
+            min_p = st.number_input("min_p", 0.0, 1.0, value=float(config["chat"]["min_p"]))
+            
+        saved = st.form_submit_button("Save")
+        if saved:
+            config["chat"]["num_ctx"] = num_ctx
+            config["chat"]["temperature"] = temperature
+            config["chat"]["repeat_last_n"] = repeat_last_n
+            config["chat"]["repeat_penalty"] = repeat_penalty
+            config["chat"]["top_k"] = top_k
+            config["chat"]["top_p"] = top_p
+            config["chat"]["min_p"] = min_p
+            st.success("Settings saved! Please refresh the app to fully apply changes.")
+            save_config()

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -17,7 +17,8 @@ def get_config() -> Dict[str, Any]:
         except Exception:
             pass  # fall through to defaults on error
     return {"repo_url": "", "gh_user": "", "gh_token": "",
-            "memory": get_memory_defaults()}
+            "memory": get_memory_defaults(),
+            "chat": get_chat_defaults()}
 
 def get_chat_defaults():
     return {"num_ctx": 2048, "temperature": 0.8, "repeat_last_n": 64, "repeat_penalty": 1.1, "top_k": 40, "top_p": 0.9, "min_p": 0.0}


### PR DESCRIPTION
Issue #25 

I added the chat settings page, divided into two panes, and with all the settings as required. I have also set the defaults as listed in the [documentation](https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values) provided in the issue.

In my previous pull request I made a mistake when trying to change the code for the dropdown menu in memory settings, in this PR I have included fixes to make it usable again, while also making it extensible.