### PR TITLE
Integrate memory and chat settings

### DIFF
--- a/aqchat/chat.py
+++ b/aqchat/chat.py
@@ -1,106 +1,12 @@
 import re
-import os
 from typing import Any, Tuple
 import streamlit as st
 import settings
 from langchain_core.messages import ToolMessage, AIMessageChunk
-from gh import extract_repo_name, GitHubRepo
-from pipelines import AbstractChatPipeline, AbstractMemoryPipeline, OllamaChatPipeline, CodeMemoryPipeline, TestingChatPipeline
+from gh import GitHubRepo
+from pipelines import AbstractChatPipeline, AbstractMemoryPipeline
 from auth import has_authorized
-from misc import get_data_dir
-
-@st.cache_resource
-def get_repo(repo_url: str, gh_user: str) -> GitHubRepo:
-    print(f"[repo] initializing {repo_url} as {gh_user}")
-    config = settings.get_config()
-    repo_name = extract_repo_name(repo_url)
-
-    return GitHubRepo(
-        repo_url,
-        get_data_dir() / "repos" / repo_name,
-        username=gh_user,
-        token=config["gh_token"]
-    )
-
-@st.cache_resource
-def get_memory_pipeline(repo_name: str) -> AbstractMemoryPipeline:
-    print(f"[pipeline] making memory pipeline for {repo_name}")
-
-    data_dir = get_data_dir()
-
-    pipeline_setting = os.environ.get('USE_CHAT_PIPELINE', "TESTING")
-
-    # If Ollama is specified, then we will call the ollama server
-    # for embeddings using the specified embedding model.
-    if pipeline_setting == "OLLAMA":
-        ollama_url = os.environ.get('OLLAMA_URL', "http://localhost:11434")
-        print(f"[pipeline] using embedding from ollama server on {ollama_url}")
-
-        ollama_embedding_model = os.environ.get('OLLAMA_EMBEDDING_MODEL', "unclemusclez/jina-embeddings-v2-base-code")
-        print(f"[pipeline] using embedding model {ollama_embedding_model}")
-    else:
-        ollama_url = None
-        ollama_embedding_model = None
-        print("[pipeline] no ollama server set; using default embedding model")
-
-    memory = CodeMemoryPipeline(
-        persist_directory=data_dir / f"chroma/{repo_name}",
-        ollama_url=ollama_url,
-        ollama_embedding_model=ollama_embedding_model
-    )
-
-    # If the pipeline didn't load the vector store from disk,
-    # then we need to process the repo for the first time.
-    if not memory.has_vector_db():
-        memory.ingest(data_dir / f"repos/{repo_name}")
-
-    return memory
-
-@st.cache_resource
-def get_chat_pipeline(repo_name: str) -> AbstractChatPipeline:
-    print(f"[pipeline] making chat pipeline")
-
-    memory = get_memory_pipeline(repo_name)
-
-    pipeline_setting = os.environ.get('USE_CHAT_PIPELINE', "TESTING")
-
-    # If Ollama is specified in the USE_CHAT_PIPELINE environment
-    # variable, then initialize the ollama chat pipeline.
-
-    # Otherwise (as in, by default) initialize the testing pipeline.
-    # In a development environment, this allows us to test
-    # the server without depending on an LLM server.
-    if pipeline_setting == "OLLAMA":
-        ollama_url = os.environ.get('OLLAMA_URL', "http://localhost:11434")
-        print(f"[pipeline] connecting to ollama server on {ollama_url}")
-
-        ollama_model = os.environ.get('OLLAMA_MODEL', "qwen3:32B")
-        print(f"[pipeline] using model {ollama_model}")
-
-        chat_pipeline = OllamaChatPipeline(
-            memory=memory,
-            ollama_url=ollama_url,
-            ollama_model=ollama_model,
-        )
-    else:
-        chat_pipeline = TestingChatPipeline(memory=memory)
-    
-    return chat_pipeline
-
-def update_repo(repo: GitHubRepo):
-    print(f"[repo,pipeline] syncing {repo.remote_url}")
-    repo_name: str = extract_repo_name(repo.remote_url)
-
-    memory: AbstractMemoryPipeline = get_memory_pipeline(repo_name)
-
-    cb = lambda path: memory.update_files(path)
-    callbacks = {
-        "added": [cb],
-        "removed": [cb],
-        "modified": [cb],
-    }
-
-    repo.pull(callbacks)
+from eng import get_repo, update_repo, get_chat_pipeline, get_memory_pipeline
 
 def get_chat_model():
     "Get an instance of the chat model"

--- a/aqchat/eng.py
+++ b/aqchat/eng.py
@@ -62,6 +62,18 @@ def get_chat_pipeline(repo_name: str) -> AbstractChatPipeline:
 
     memory = get_memory_pipeline(repo_name)
 
+    # memory pipeline is cached, so we can update memory settings here.
+    # Otherwise, memory settings might never be updated.
+    # Right now, every time a client connects or refreshes the page:
+    # -> memory settings updated
+    # -> chat settings updated
+    memory_settings = settings.get_config().get("memory")
+    if memory_settings:
+        memory.set_retrieval_settings(memory_settings)
+
+    # get chat settings from the config
+    chat_settings = settings.get_config().get("chat")
+
     pipeline_setting = os.environ.get('USE_CHAT_PIPELINE', "TESTING")
 
     # If Ollama is specified in the USE_CHAT_PIPELINE environment
@@ -81,6 +93,7 @@ def get_chat_pipeline(repo_name: str) -> AbstractChatPipeline:
             memory=memory,
             ollama_url=ollama_url,
             ollama_model=ollama_model,
+            chat_settings=chat_settings
         )
     else:
         chat_pipeline = TestingChatPipeline(memory=memory)

--- a/aqchat/eng.py
+++ b/aqchat/eng.py
@@ -52,9 +52,13 @@ def get_memory_pipeline(repo_name: str) -> AbstractMemoryPipeline:
 
     return memory
 
-@st.cache_resource
 def get_chat_pipeline(repo_name: str) -> AbstractChatPipeline:
-    print(f"[pipeline] making chat pipeline")
+    chat_pipeline = st.session_state.get("chat_pipeline")
+    if chat_pipeline:
+        print(f"[pipeline] acquired existing chat pipeline for {repo_name}")
+        return chat_pipeline
+
+    print(f"[pipeline] making chat pipeline for {repo_name}")
 
     memory = get_memory_pipeline(repo_name)
 
@@ -81,6 +85,7 @@ def get_chat_pipeline(repo_name: str) -> AbstractChatPipeline:
     else:
         chat_pipeline = TestingChatPipeline(memory=memory)
     
+    st.session_state["chat_pipeline"] = chat_pipeline
     return chat_pipeline
 
 def update_repo(repo: GitHubRepo):

--- a/aqchat/eng.py
+++ b/aqchat/eng.py
@@ -1,0 +1,99 @@
+import os
+import streamlit as st
+from gh import extract_repo_name, GitHubRepo
+import settings
+from pipelines import AbstractChatPipeline, AbstractMemoryPipeline, OllamaChatPipeline, CodeMemoryPipeline, TestingChatPipeline
+from misc import get_data_dir
+
+@st.cache_resource
+def get_repo(repo_url: str, gh_user: str) -> GitHubRepo:
+    print(f"[repo] initializing {repo_url} as {gh_user}")
+    config = settings.get_config()
+    repo_name = extract_repo_name(repo_url)
+
+    return GitHubRepo(
+        repo_url,
+        get_data_dir() / "repos" / repo_name,
+        username=gh_user,
+        token=config["gh_token"]
+    )
+
+@st.cache_resource
+def get_memory_pipeline(repo_name: str) -> AbstractMemoryPipeline:
+    print(f"[pipeline] making memory pipeline for {repo_name}")
+
+    data_dir = get_data_dir()
+
+    pipeline_setting = os.environ.get('USE_CHAT_PIPELINE', "TESTING")
+
+    # If Ollama is specified, then we will call the ollama server
+    # for embeddings using the specified embedding model.
+    if pipeline_setting == "OLLAMA":
+        ollama_url = os.environ.get('OLLAMA_URL', "http://localhost:11434")
+        print(f"[pipeline] using embedding from ollama server on {ollama_url}")
+
+        ollama_embedding_model = os.environ.get('OLLAMA_EMBEDDING_MODEL', "unclemusclez/jina-embeddings-v2-base-code")
+        print(f"[pipeline] using embedding model {ollama_embedding_model}")
+    else:
+        ollama_url = None
+        ollama_embedding_model = None
+        print("[pipeline] no ollama server set; using default embedding model")
+
+    memory = CodeMemoryPipeline(
+        persist_directory=data_dir / f"chroma/{repo_name}",
+        ollama_url=ollama_url,
+        ollama_embedding_model=ollama_embedding_model
+    )
+
+    # If the pipeline didn't load the vector store from disk,
+    # then we need to process the repo for the first time.
+    if not memory.has_vector_db():
+        memory.ingest(data_dir / f"repos/{repo_name}")
+
+    return memory
+
+@st.cache_resource
+def get_chat_pipeline(repo_name: str) -> AbstractChatPipeline:
+    print(f"[pipeline] making chat pipeline")
+
+    memory = get_memory_pipeline(repo_name)
+
+    pipeline_setting = os.environ.get('USE_CHAT_PIPELINE', "TESTING")
+
+    # If Ollama is specified in the USE_CHAT_PIPELINE environment
+    # variable, then initialize the ollama chat pipeline.
+
+    # Otherwise (as in, by default) initialize the testing pipeline.
+    # In a development environment, this allows us to test
+    # the server without depending on an LLM server.
+    if pipeline_setting == "OLLAMA":
+        ollama_url = os.environ.get('OLLAMA_URL', "http://localhost:11434")
+        print(f"[pipeline] connecting to ollama server on {ollama_url}")
+
+        ollama_model = os.environ.get('OLLAMA_MODEL', "qwen3:32B")
+        print(f"[pipeline] using model {ollama_model}")
+
+        chat_pipeline = OllamaChatPipeline(
+            memory=memory,
+            ollama_url=ollama_url,
+            ollama_model=ollama_model,
+        )
+    else:
+        chat_pipeline = TestingChatPipeline(memory=memory)
+    
+    return chat_pipeline
+
+def update_repo(repo: GitHubRepo):
+    print(f"[repo,pipeline] syncing {repo.remote_url}")
+    repo_name: str = extract_repo_name(repo.remote_url)
+
+    memory: AbstractMemoryPipeline = get_memory_pipeline(repo_name)
+
+    cb = lambda path: memory.update_files(path)
+    callbacks = {
+        "added": [cb],
+        "removed": [cb],
+        "modified": [cb],
+    }
+
+    repo.pull(callbacks)

--- a/aqchat/pipelines/abstract_memory.py
+++ b/aqchat/pipelines/abstract_memory.py
@@ -1,5 +1,5 @@
 import os
-from typing import List
+from typing import List, Dict, Any
 
 from langchain_core.documents import Document
 
@@ -45,3 +45,24 @@ class AbstractMemoryPipeline:
         """Invoke the memory retriever and return the resulting documents."""
         raise NotImplementedError
     
+    def set_retrieval_settings(self, retrieval_settings: Dict[str, Any]) -> None:
+        """Update retrieval settings.
+        
+        Retrieval settings MUST be a dict of the form:
+
+        ```
+        {
+            "ret_strat": "mmr", "k": 6, "fetch_k": 20, "lambda_mult": 0.5
+        }
+        ```
+
+        OR:
+        ```
+        {
+            "ret_strat": "similarity", "k": 4
+        }
+        ```
+        """
+        with self.lock:
+            self.retrieval_settings = retrieval_settings
+            self._build_chain()

--- a/aqchat/pipelines/ollama_chat_pipeline.py
+++ b/aqchat/pipelines/ollama_chat_pipeline.py
@@ -1,5 +1,5 @@
 from threading import Lock
-from typing import Dict, List, Sequence, Iterator
+from typing import Dict, List, Any, Iterator
 
 from langchain_core.tools import tool
 from langchain_core.messages.base import BaseMessageChunk
@@ -26,6 +26,7 @@ class OllamaChatPipeline(AbstractChatPipeline):
         *,
         ollama_model: str = "qwen3:32B",
         ollama_url: str | None = None,
+        chat_settings: Dict[str, Any] = None
     ) -> None:
         # allocate mutex
         self.lock = Lock()
@@ -34,7 +35,11 @@ class OllamaChatPipeline(AbstractChatPipeline):
         # ChatOllama does not support tool calling unfortunately.
         # However, ollama provides an OpenAI-compatible API wrapper, so we can use
         # ChatOpenAI, which *does* work with tool calling.
-        self.model = ChatOpenAI(model=ollama_model, base_url=ollama_url + "/v1", api_key="ollama")
+        self.model = ChatOpenAI(model=ollama_model,
+                                base_url=ollama_url + "/v1",
+                                api_key="ollama",
+                                temperature=chat_settings.get("temperature") if chat_settings else None,
+                                )
 
         self.tools = []
         self.memory = memory

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -54,7 +54,7 @@ def get_chat_defaults():
 
 def get_memory_defaults():
     return {"ret_strat": "mmr", 
-            "k_int": 6, 
+            "k": 6, 
             "fetch_k": 20, 
             "lambda_mult": 0.5}
 
@@ -126,14 +126,14 @@ def memory_settings():
     options = ["MMR", "Similarity"]
     ret_strat = st.selectbox("Retrieval Strategy", options, index=dict_options.index(config["memory"]["ret_strat"]))
     current_index = options.index(ret_strat)
-    k_int = st.number_input("k", 1, 10, value=int(config["memory"]["k_int"]))
+    k_int = st.number_input("k", 1, 10, value=int(config["memory"]["k"]))
     disable_widget = ret_strat != "MMR"
     fetch_k = st.number_input("Fetch k", 10, 100, value=int(config["memory"]["fetch_k"]) , disabled=disable_widget)
     lambda_mult = st.number_input("Lambda mult", 0.0, 1.0, value=float(config["memory"]["lambda_mult"]), disabled=disable_widget)
     saved = st.button("Save")
     if saved:
         config["memory"]["ret_strat"] = dict_options[current_index]
-        config["memory"]["k_int"] = k_int
+        config["memory"]["k"] = k_int
         config["memory"]["fetch_k"] = fetch_k
         config["memory"]["lambda_mult"] = lambda_mult
         st.success("Settings saved! Please refresh the app to fully apply changes.")

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -143,6 +143,10 @@ def chat_settings():
     st.title("Chat Settings")
     config=get_config()
 
+    # Currently, only temperature setting is actually supported, because of the OpenAI backend layer
+    # not being compatible with many settings which ollama otherwise accepts.
+    # These settings are disabled in the UI.
+
     with st.form(key="chat_settings"):
         with st.container(border=True) as context:
             st.header("Context")

--- a/aqchat/settings.py
+++ b/aqchat/settings.py
@@ -146,16 +146,16 @@ def chat_settings():
     with st.form(key="chat_settings"):
         with st.container(border=True) as context:
             st.header("Context")
-            num_ctx = st.number_input("num_ctx", 512, 131072, value=int(config["chat"]["num_ctx"]))
+            num_ctx = st.number_input("num_ctx", 512, 131072, value=int(config["chat"]["num_ctx"]), disabled=True)
 
         with st.container(border=True) as generation:
             st.header("Generation")
             temperature = st.number_input("temperature", 0.0, 1.0, value=float(config["chat"]["temperature"]))
-            repeat_last_n = st.number_input("repeat_last_n", -1, 512, value=int(config["chat"]["repeat_last_n"]))
-            repeat_penalty = st.number_input("repeat_penalty", 0.0, 2.0, value=float(config["chat"]["repeat_penalty"]))
-            top_k = st.number_input("top_k", 0, 100, value=int(config["chat"]["top_k"]))
-            top_p = st.number_input("top_p", 0.0, 1.0, value=float(config["chat"]["top_p"]))
-            min_p = st.number_input("min_p", 0.0, 1.0, value=float(config["chat"]["min_p"]))
+            repeat_last_n = st.number_input("repeat_last_n", -1, 512, value=int(config["chat"]["repeat_last_n"]), disabled=True)
+            repeat_penalty = st.number_input("repeat_penalty", 0.0, 2.0, value=float(config["chat"]["repeat_penalty"]), disabled=True)
+            top_k = st.number_input("top_k", 0, 100, value=int(config["chat"]["top_k"]), disabled=True)
+            top_p = st.number_input("top_p", 0.0, 1.0, value=float(config["chat"]["top_p"]), disabled=True)
+            min_p = st.number_input("min_p", 0.0, 1.0, value=float(config["chat"]["min_p"]), disabled=True)
             
         saved = st.form_submit_button("Save")
         if saved:


### PR DESCRIPTION
Resolves https://github.com/JFarAur/aqchat/issues/31.

To support this, code was refactored a bit, separating the memory and chat pipeline factories into a new file.

Chat pipeline is now in session state, rather than being a streamlit cache variable. On an aside, this also means things are a bit less messy if multiple clients connect at the same time.

Every time the page is refreshed and the user starts a new chat, `get_chat_pipeline()` is called to get a new pipeline. At that point, current settings are pulled, both memory and chat, and the pipelines have their settings updated.

Since the switch to OpenAI API compatibility layer, many of the chat generation settings are actually not modifiable through the API. So currently only temperature is supported.

UI was adjusted slightly, all settings except temperature have their fields disabled.

Also: Settings were updated so that if a config file is already present, then missing entries are updated with defaults. Previously, if a partial config file was present, (i.e. only Git settings, no chat or memory settings) then there would be a KeyError, because this would be loaded instead of defaults being used. However, this is now resolved.

Nested dicts inside the config dict will also be recursively updated, so if parts of a nested dict are missing, only they will be updated. This will be good for backward compatibility with settings files from previous versions.