### PR TITLE
Rewrite abstract_chat and abstract_memory to utilize Python ABC module.

### DIFF
--- a/aqchat/pipelines/abstract_chat.py
+++ b/aqchat/pipelines/abstract_chat.py
@@ -1,8 +1,9 @@
 from typing import Dict, List, Iterator
 
 from langchain_core.messages.base import BaseMessageChunk
+from abc import ABC, abstractmethod
 
-class AbstractChatPipeline:
+class AbstractChatPipeline(ABC):
     """This interface represents an LLM chat pipeline which can be
     queried with a memory interface and a current message list.
 
@@ -15,6 +16,7 @@ class AbstractChatPipeline:
     # PUBLIC API
     # --------------------------------------------------------------
 
+    @abstractmethod
     def query(self, messages: List[Dict[str, str]]) -> Iterator[BaseMessageChunk]:
         """Stream an answer for *messages*.
 
@@ -22,6 +24,6 @@ class AbstractChatPipeline:
         ``[{"role": "user" | "assistant" | "system", "content": "..."}, ...]``.
         The final user message is treated as the question for retrieval.
         """
-        raise NotImplementedError
+        pass
 
     

--- a/aqchat/pipelines/abstract_memory.py
+++ b/aqchat/pipelines/abstract_memory.py
@@ -1,9 +1,10 @@
 import os
 from typing import List, Dict, Any
+from abc import ABC, abstractmethod
 
 from langchain_core.documents import Document
 
-class AbstractMemoryPipeline:
+class AbstractMemoryPipeline(ABC):
     """This interface represents a pipeline for indexing
     and maintaining a database over some kind of file system which
     backs memory retrieval.
@@ -17,33 +18,40 @@ class AbstractMemoryPipeline:
     # PUBLIC API
     # --------------------------------------------------------------
 
+    @abstractmethod
     def ingest(self, repo_path: str | os.PathLike) -> None:
         """Walk *repo_path*, index eligible files, and build the retrieval chain."""
-        raise NotImplementedError
+        pass
 
+    @abstractmethod  
     def update_files(self, *file_paths: str | os.PathLike) -> None:
         """(Re)-index *file_paths* that were modified since the last ingest."""
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def clear(self) -> None:
         """Clear *in-memory* state - keep the persisted DB intact."""
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def has_vector_db(self) -> bool:
         """Return True if there is a loaded vector store present."""
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def clear_vector_db(self) -> None:
         """Delete the persisted database on disk and reset state."""
-        raise NotImplementedError
-    
+        pass
+
+    @abstractmethod    
     def ready_for_retrieval(self) -> bool:
         """Returns True if the pipeline is ready to be used."""
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def invoke(self, input: str) -> List[Document]:
         """Invoke the memory retriever and return the resulting documents."""
-        raise NotImplementedError
+        pass
     
     def set_retrieval_settings(self, retrieval_settings: Dict[str, Any]) -> None:
         """Update retrieval settings.


### PR DESCRIPTION
Issue #32

I rewrote `abstract_chat.py` and `abstract_memory.py` to utilize Python's `abc` module. Now the abstract classes inherit `ABC`, and with the `@abstractmethod` decorator there no longer a need to use `raise NotImplementedError` for every abstract method.